### PR TITLE
Fixed to return misp response when sns post is uploaded to MISP

### DIFF
--- a/src/ctirs/core/adapter/misp/upload/control.py
+++ b/src/ctirs/core/adapter/misp/upload/control.py
@@ -35,7 +35,7 @@ class MispUploadAdapterControl(object):
             misp_event.add_tag(tag)
         resp = self.py_misp.add_event(misp_event)
         if resp.has_key('Event') == True:
-            return
+            return resp
         else:
             raise Exception(str(resp['errors']))
 


### PR DESCRIPTION
Thanks for reporting.
I forgot to return MISP response.
So, S-TIP SNS can get a MISP Event ID, 500 internal error occurred.
I fix to return MISP response.
