### PR TITLE
Add three functions as REST APIs

### DIFF
--- a/bin/delete_stix.py
+++ b/bin/delete_stix.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import json
+import requests
+import argparse
+
+##############################
+# delete_stix
+# STIX 削除
+##############################
+# 第1引数：URL (http(s)://host:port/api/vi/stix_files_package_id/)
+# 第2引数：username
+# 第3引数：apikey
+# 第4引数：package_id
+##############################
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Delete STIX Script')
+    parser.add_argument('url', help='url')
+    parser.add_argument('user_name', help='user name')
+    parser.add_argument('apikey', help='apikey')
+    parser.add_argument('package_id', help='package id')
+    args = parser.parse_args()
+
+    # 認証情報
+    headers = {
+        'username': args.user_name,
+        'apikey': args.apikey,
+    }
+
+    url = '%s%s' % (args.url, args.package_id)
+
+    # リクエスト送信
+    r = requests.delete(
+        url,
+        headers=headers,
+        verify=False)
+
+    # response 解析
+    b = json.loads(r.text)
+    if r.status_code != 200:
+        print 'Request Failed (%s).' % (r.status_code)
+        sys.exit(os.EX_UNAVAILABLE)
+    else:
+        print 'Success!'
+        sys.exit(os.EX_OK)

--- a/src/ctirs/api/v1/package_id/urls.py
+++ b/src/ctirs/api/v1/package_id/urls.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# URLを正規表現で評価し、マッチングした場合の処理箇所を定義
+from django.conf.urls import url
+import ctirs.api.v1.package_id.views as package_id
+
+urlpatterns = [
+    # STIX 取得
+    url(r'^(?P<package_id>\S+)/stix$', package_id.stix_files_package_id_stix),
+    # 関連 STIX 取得
+    url(r'^(?P<package_id>\S+)/related_packages$', package_id.stix_files_package_id_related_packages),
+    # STIXファイル情報取得/削除　
+    url(r'^(?P<package_id>\S+)$', package_id.stix_files_package_id),
+
+]

--- a/src/ctirs/api/v1/package_id/views.py
+++ b/src/ctirs/api/v1/package_id/views.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from django.http import HttpResponseNotAllowed
+from django.views.decorators.csrf import csrf_exempt
+from django.http.response import JsonResponse
+import ctirs.api as api_root
+from ctirs.core.mongo.documents_stix import StixFiles
+from ctirs.api.v1.gv.views import get_matched_packages
+
+# STIXファイル情報取得/削除
+# /api/v1/stix_files_package_id/<package_id>
+@csrf_exempt
+def stix_files_package_id(request, package_id):
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
+    if ctirs_auth_user is None:
+        return api_root.error(Exception('You have no permission for this operation.'))
+    try:
+        if request.method == 'GET':
+            # STIX ファイル情報取得
+            return get_stix_file_package_id_document_info(request, package_id)
+        elif request.method == 'DELETE':
+            # STIX ファイル情報削除
+            delete_stix_file_package_id_document_info(package_id)
+            return api_root.get_delete_normal_status()
+        else:
+            return HttpResponseNotAllowed(['GET', 'DELETE'])
+    except Exception as e:
+        return api_root.error(e)
+
+# STIX ファイル情報取得
+# GET /api/v1/stix_files_package_id/<package_id>
+def get_stix_file_package_id_document_info(request, package_id):
+    try:
+        doc = StixFiles.objects.get(package_id=package_id)
+        return api_root.get_rest_api_document_info(doc)
+    except Exception as _:
+        return api_root.error(Exception('The specified id not found.'))
+
+# STIX ファイル情報削除
+# DELETE /api/v1/stix_files_package_id/<package_id>
+def delete_stix_file_package_id_document_info(package_id):
+    try:
+        api_root.delete_stix_document(package_id=package_id)
+    except Exception as e:
+        return api_root.error(e)
+
+# STIX ファイル取得
+# GET /api/v1/stix_files_package_id/<package_id>/stix
+def stix_files_package_id_stix(request, package_id):
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
+    if ctirs_auth_user is None:
+        return api_root.error(Exception('You have no permission for this operation.'))
+    try:
+        doc = StixFiles.objects.get(package_id=package_id)
+        return api_root.get_rest_api_document_content(doc)
+    except Exception as e:
+        return api_root.error(e)
+
+# 関連 CTI 取得
+# GET /api/v1/stix_files_package_id/<package_id>/related_packages
+def stix_files_package_id_related_packages(request, package_id):
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
+    if ctirs_auth_user is None:
+        return api_root.error(Exception('You have no permission for this operation.'))
+    try:
+        ret = get_matched_packages(package_id)
+        return JsonResponse(ret, safe=False)
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        return api_root.error(e)

--- a/src/ctirs/api/v1/stix_files/urls.py
+++ b/src/ctirs/api/v1/stix_files/urls.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-#URLを正規表現で評価し、マッチングした場合の処理箇所を定義
+# URLを正規表現で評価し、マッチングした場合の処理箇所を定義
 from django.conf.urls import url
 import ctirs.api.v1.stix_files.views as stix_files
 
-urlpatterns =[
-    #stix取得
+urlpatterns = [
+    # STIX 取得
     url(r'^(?P<id_>\S+)/stix$', stix_files.stix_files_id_stix),
-    #STIXファイル情報取得
+    # STIX ファイル情報取得/削除
     url(r'^(?P<id_>\S+)$', stix_files.stix_files_id),
 ]

--- a/src/ctirs/api/v1/stix_files/views.py
+++ b/src/ctirs/api/v1/stix_files/views.py
@@ -5,125 +5,155 @@ from mongoengine.errors import DoesNotExist
 from django.http import HttpResponseNotAllowed
 from django.views.decorators.csrf import csrf_exempt
 from django.http.response import JsonResponse
-from ctirs.api import error,get_put_normal_status,authentication
+import ctirs.api as api_root
 from ctirs.core.mongo.documents import Communities, Vias
 from ctirs.core.mongo.documents_stix import StixFiles
 from ctirs.core.common import get_text_field_value
 from ctirs.upload.views import upload_common
 
-def get_api_get_stix_files_community(request):
-    return get_text_field_value(request,'community',default_value=None)
-def get_api_get_stix_files_start(request):
-    return get_text_field_value(request,'start',default_value=None)
-def get_api_get_stix_files_end(request):
-    return get_text_field_value(request,'end',default_value=None)
 
-#/api/v1/stix_files
-#GET/POSTの受付
+def get_api_get_stix_files_community(request):
+    return get_text_field_value(request, 'community', default_value=None)
+
+
+def get_api_get_stix_files_start(request):
+    return get_text_field_value(request, 'start', default_value=None)
+
+
+def get_api_get_stix_files_end(request):
+    return get_text_field_value(request, 'end', default_value=None)
+
+# /api/v1/stix_files
+# GET/POSTの受付
 @csrf_exempt
 def stix_files(request):
     try:
         if request.method == 'GET':
-            #stix_file一覧取得
+            # stix_file一覧取得
             return get_stix_files(request)
         elif request.method == 'POST':
-            #stix_file追加
+            # stix_file追加
             return upload_stix_file(request)
         else:
-            return HttpResponseNotAllowed(['GET','POST'])
+            return HttpResponseNotAllowed(['GET', 'POST'])
     except Exception as e:
-        return error(e)
+        return api_root.error(e)
 
-#引数の日時文字列からdatetimeオブジェクトを作成
+# 引数の日時文字列からdatetimeオブジェクトを作成
 def get_datetime_from_argument(s):
-    return datetime.datetime.strptime(s,'%Y%m%d%H%M%S').replace(tzinfo=pytz.utc)
+    return datetime.datetime.strptime(s, '%Y%m%d%H%M%S').replace(tzinfo=pytz.utc)
 
-#stix_file一覧取得
-#GET /api/v1/stix_files
+# stix_file一覧取得
+# GET /api/v1/stix_files
 def get_stix_files(request):
-    #apikey認証
-    ctirs_auth_user = authentication(request)
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
     if ctirs_auth_user is None:
-        return error(Exception('You have no permission for this operation.'))
+        return api_root.error(Exception('You have no permission for this operation.'))
 
     l = []
     query = {}
-    #community filter
+    # community filter
     community = get_api_get_stix_files_community(request)
     if community is not None:
         try:
             query['input_community'] = Communities.objects.get(name=community)
         except DoesNotExist:
-            return error(Exception('The specified community not found.'))
+            return api_root.error(Exception('The specified community not found.'))
 
-    #start filter
-    #YYYYMMDDHHMMSS形式
+    # start filter
+    # YYYYMMDDHHMMSS形式
     start = get_api_get_stix_files_start(request)
     if start is not None:
         try:
             d = get_datetime_from_argument(start)
             query['created__gt'] = d
-        except:
-            return error(Exception('Time string format invalid.'))
+        except Exception as _:
+            return api_root.error(Exception('Time string format invalid.'))
     
-    #end filter
-    #YYYYMMDDHHMMSS形式
+    # end filter
+    # YYYYMMDDHHMMSS形式
     end = get_api_get_stix_files_end(request)
     if end is not None:
         try:
             d = get_datetime_from_argument(end)
             query['created__lt'] = d
-        except:
-            return error(Exception('Time string format invalid.'))
+        except Exception as _:
+            return api_root.error(Exception('Time string format invalid.'))
 
-    #検索
+    # 検索
     for stix_files in StixFiles.objects.filter(**query):
         try:
             l.append(stix_files.get_rest_api_document_info())
         except DoesNotExist:
             pass
-    return JsonResponse(l,safe=False)
+    return JsonResponse(l, safe=False)
 
-#STIXファイル追加
-#POST /api/v1/stix_files
+# STIXファイル追加
+# POST /api/v1/stix_files
 def upload_stix_file(request):
-    #apikey認証
-    ctirs_auth_user = authentication(request)
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
     if ctirs_auth_user is None:
-        return error(Exception('You have no permission for this operation.'))
+        return api_root.error(Exception('You have no permission for this operation.'))
     try:
-        #viaを取得
+        # viaを取得
         via = Vias.get_via_rest_api_upload(uploader=ctirs_auth_user.id)
-        upload_common(request,via)
-        return get_put_normal_status()
+        upload_common(request, via)
+        return api_root.get_put_normal_status()
     except Exception as e:
         import traceback
         traceback.print_exc()
-        return error(e)
+        return api_root.error(e)
 
 
-#STIXファイル情報取得
-#GET /api/v1/stix_files/<id>
-def stix_files_id(request,id_):
-    #apikey認証
-    ctirs_auth_user = authentication(request)
+# STIXファイル情報取得/削除
+# /api/v1/stix_files/<id_>
+@csrf_exempt
+def stix_files_id(request, id_):
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
     if ctirs_auth_user is None:
-        return error(Exception('You have no permission for this operation.'))
+        return api_root.error(Exception('You have no permission for this operation.'))
+    try:
+        if request.method == 'GET':
+            # STIX ファイル情報取得
+            return get_stix_file_document_info(request, id_)
+        elif request.method == 'DELETE':
+            # STIX ファイル情報削除
+            delete_stix_file_document_info(id_)
+            return api_root.get_delete_normal_status()
+        else:
+            return HttpResponseNotAllowed(['GET', 'DELETE'])
+    except Exception as e:
+        return api_root.error(e)
+
+# STIX ファイル情報取得
+# GET /api/v1/stix_files/<id_>
+def get_stix_file_document_info(request, id_):
     try:
         doc = StixFiles.objects.get(id=id_)
-        return JsonResponse(doc.get_rest_api_document_info(),safe=False)
-    except DoesNotExist:
-        return error(Exception('The specified id not found.'))
+        return api_root.get_rest_api_document_info(doc)
+    except Exception as _:
+        return api_root.error(Exception('The specified id not found.'))
 
-#STIX取得
-#GET /api/v1/stix_files/<id>/stix
-def stix_files_id_stix(request,id_):
-    #apikey認証
-    ctirs_auth_user = authentication(request)
+# STIX ファイル情報削除
+# DELETE /api/v1/stix_files/<id_>
+def delete_stix_file_document_info(id_):
+    try:
+        api_root.delete_stix_document(id_=id_)
+    except Exception as e:
+        return api_root.error(e)
+
+# STIX取得
+# GET /api/v1/stix_files/<id>/stix
+def stix_files_id_stix(request, id_):
+    # apikey認証
+    ctirs_auth_user = api_root.authentication(request)
     if ctirs_auth_user is None:
-        return error(Exception('You have no permission for this operation.'))
+        return api_root.error(Exception('You have no permission for this operation.'))
     try:
         doc = StixFiles.objects.get(id=id_)
-        return JsonResponse(doc.get_rest_api_document_content(),safe=False)
+        return api_root.get_rest_api_document_content(doc)
     except DoesNotExist:
-        return error(Exception('The specified id not found.'))
+        return api_root.error(Exception('The specified id not found.'))

--- a/src/ctirs/api/v1/urls.py
+++ b/src/ctirs/api/v1/urls.py
@@ -1,22 +1,25 @@
 # -*- coding: utf-8 -*-
 
-#URLを正規表現で評価し、マッチングした場合の処理箇所を定義
+# URLを正規表現で評価し、マッチングした場合の処理箇所を定義
 import ctirs.api.v1.stix_files.urls
+import ctirs.api.v1.package_id.urls
 import ctirs.api.v1.stix_files_v2.urls
 import ctirs.api.v1.gv.urls
 import ctirs.api.v1.sns.urls
 
-from django.conf.urls import url,include
+from django.conf.urls import url, include
 from ctirs.api.v1.stix_files.views import stix_files
 
 urlpatterns = [
-    #stix_file
+    # stix_file
     url(r'^stix_files$', stix_files),
     url(r'^stix_files/', include(ctirs.api.v1.stix_files.urls)),
-    #stix_file
+    # stix_file (package_id)
+    url(r'^stix_files_package_id/', include(ctirs.api.v1.package_id.urls)),
+    # stix_file (v2)
     url(r'^stix_files_v2/', include(ctirs.api.v1.stix_files_v2.urls)),
-    #gv
+    # gv
     url(r'^gv/', include(ctirs.api.v1.gv.urls)),
-    #sns
+    # sns
     url(r'^sns/', include(ctirs.api.v1.sns.urls)),
 ]


### PR DESCRIPTION
I add three function as REST APIs and a console script.

1.  **DELETE /api/v1/stix_files_package_id/<package_id>
DELETE /api/v1/stix_files/<mongo_id>**
This API enables you to delete the specified STIX file and record from S-TIP Repository System Database.
I also added /bin/delete_stix.py. We can delete a stix file from the CUI.
<pre>
python delete_stix.py url  username apikey package_id 
</pre>
The format of url is "http(s)://<stip-host>:<stip-port>/api/v1/stix_files_package_id/".

2. **GET /api/v1/stix_files_package_id/<package_id>/stix**
This API enables you to get the stix content which you specify by package_id.
S-TIP already has been able to get this content by <mongo_id> (GET /api/v1/stix_files/<mongo_id>/stix)

3. **GET /api/v1/stix_files_package_id/<package_id>/related_packages**
This API enables you to get related CTI  with a specified package_id from S-TIP database like graph view function.
Response format is below.
<pre>
[
    {
        "package_id":  <stix_package_id (str)>,
        "package_name": <stix_package_name (str)>,
        "exact":  3 (number of same value pair (integer)
    },
   ....

]
</pre>

If there are no related packages, this api returned [].
