### PR TITLE
Fixed an issue about uploading and downloading a file with a  Japanese filename

### DIFF
--- a/src/ctirs/models/sns/feeds/models.py
+++ b/src/ctirs/models/sns/feeds/models.py
@@ -220,6 +220,7 @@ class Feed(models.Model):
 
         # ファイル保存
         file_path = attachment_stix_dir + os.sep + file_name
+        file_path = file_path.encode('utf-8')
         with open(file_path, 'wb') as fp:
             fp.write(content)
         attach_file = AttachFile()


### PR DESCRIPTION
I found also that an end user failed to upload a file with a Japanese file name via SNS timeline.
I addressed this issue.
