### PR TITLE
Don't delete certificate settings when another setting items are modi…

### DIFF
--- a/src/ctirs/configuration/taxii_client/views.py
+++ b/src/ctirs/configuration/taxii_client/views.py
@@ -43,11 +43,11 @@ def get_taxii_client_create_ca(request):
 
 
 def get_taxii_client_create_certificate(request):
-    return get_text_field_value(request, 'certificate', default_value=None)
+    return get_text_field_value(request, 'certificate', default_value='')
 
 
 def get_taxii_client_create_private_key(request):
-    return get_text_field_value(request, 'private_key', default_value=None)
+    return get_text_field_value(request, 'private_key', default_value='')
 
 
 def get_taxii_client_create_community_id(request):

--- a/src/ctirs/configuration/taxii_client/views.py
+++ b/src/ctirs/configuration/taxii_client/views.py
@@ -124,10 +124,6 @@ def create(request):
         push = get_taxii_client_create_push(request)
         uploader_id = int(get_taxii_client_create_uploader_id(request))
         if(ca):
-            if certificate is None:
-                return error_page_free_format(request, 'No Certificate.')
-            if private_key is None:
-                return error_page_free_format(request, 'No Private Key.')
             if ssl is not True:
                 return error_page_free_format(request, 'Use SSL.')
         else:

--- a/src/ctirs/configuration/taxii_client/views.py
+++ b/src/ctirs/configuration/taxii_client/views.py
@@ -96,10 +96,10 @@ def create(request):
         return error_page_inactive(request)
     try:
         setting_name = get_taxii_client_create_display_name(request)
-        if(setting_name is None or len(setting_name) == 0):
+        if not setting_name:
             return error_page_free_format(request, 'No Display Name.')
         address = get_taxii_client_create_address(request)
-        if(address is None or len(address) == 0):
+        if not address:
             return error_page_free_format(request, 'No Address.')
         try:
             port = get_taxii_client_create_port(request)
@@ -108,10 +108,10 @@ def create(request):
         except ValueError:
             return error_page_free_format(request, 'Invalid port.')
         path = get_taxii_client_create_path(request)
-        if(path is None or len(path) == 0):
+        if not path:
             return error_page_free_format(request, 'No Path.')
         collection = get_taxii_client_create_collection(request)
-        if(collection is None or len(collection) == 0):
+        if not collection:
             return error_page_free_format(request, 'No Collection.')
         login_id = get_taxii_client_create_login_id(request)
         login_password = get_taxii_client_create_login_password(request)
@@ -123,11 +123,11 @@ def create(request):
         protocol_version = get_taxii_client_create_protocol_version(request)
         push = get_taxii_client_create_push(request)
         uploader_id = int(get_taxii_client_create_uploader_id(request))
-        if(ca):
-            if ssl is not True:
+        if ca:
+            if not ssl:
                 return error_page_free_format(request, 'Use SSL.')
         else:
-            if(login_id is None or len(login_id) == 0):
+            if not login_id:
                 return error_page_free_format(request, 'No Login ID.')
 
         # taxii作成

--- a/src/ctirs/core/mongo/documents.py
+++ b/src/ctirs/core/mongo/documents.py
@@ -528,7 +528,7 @@ class TaxiiClients(Document):
             t.login_password = login_password
         t.community = community
         t.is_use_cert = ca
-        if ca is True:
+        if ca:
             if key_file:
                 t.key_file = key_file
             if cert_file:

--- a/src/ctirs/core/mongo/documents.py
+++ b/src/ctirs/core/mongo/documents.py
@@ -524,12 +524,15 @@ class TaxiiClients(Document):
         t.path = path
         t.collection = collection
         t.login_id = login_id
-        t.login_password = login_password
+        if login_password:
+            t.login_password = login_password
         t.community = community
         t.is_use_cert = ca
         if ca is True:
-            t.key_file = key_file
-            t.cert_file = cert_file
+            if key_file:
+                t.key_file = key_file
+            if cert_file:
+                t.cert_file = cert_file
         else:
             t.key_file = None
             t.cert_file = None

--- a/src/static/ctirs/js/taxii_client_configuration.js
+++ b/src/static/ctirs/js/taxii_client_configuration.js
@@ -88,6 +88,10 @@ $(function(){
                 modify_taxii_error('Enter Login ID');
                 return;
             }
+            // certificate
+            $('#create-certificate').val('');
+            // private_key
+            $('#create-private-key').val('');
         }
     	//Community check
         var community = $('#create-community-id').val();

--- a/src/static/ctirs/js/taxii_client_configuration.js
+++ b/src/static/ctirs/js/taxii_client_configuration.js
@@ -77,16 +77,6 @@ $(function(){
         }
         //Use Certificate Authencationチェック時
         if($('#create-ca').prop('checked') == true){
-            var certificate = $('#create-certificate').val();
-            if(certificate.length == 0){
-                modify_taxii_error('Enter Certificate');
-                return;
-            }
-            var private_key = $('#create-private-key').val();
-            if(private_key.length == 0){
-                modify_taxii_error('Enter Private Key');
-                return;
-            }
             if($('#create-ssl').prop('checked') == false){
                 modify_taxii_error('Not checked  Use SSL.');
                 return;


### PR DESCRIPTION
…fied and saved. #49

- When a user overwrites settings with an empty Certificate or Private Key, S-TIP should not overwrite them.
- When a user would like to modify to unuse a certification authentication, a user set the checkbox unchecked.

----

- password、Certificate、Private Keyが空のときは上書きせず設定を保持する。
- 証明書を利用しないようにするには「Use Certificate Authentication」のチェックを外す。