### PR TITLE
Fixed an issue about delete rest API functions

### DIFF
--- a/src/ctirs/api/__init__.py
+++ b/src/ctirs/api/__init__.py
@@ -121,19 +121,3 @@ def delete_stix_document(id_=None, package_id=None):
     if os.path.exists(origin_path):
         os.remove(origin_path)
     return
-
-
-def delete_stix_related_document(package_id=None):
-    if package_id:
-        # mongoのdocument削除
-        origin_paths, remove_package_ids = StixFiles.delete_by_related_packages(package_id)
-        # ファイル削除
-        for origin_path in origin_paths:
-            try:
-                os.remove(origin_path)
-            # ファイルが見つからない、ディレクトリのときは無視する
-            except FileNotFoundError:
-                pass
-            except IsADirectoryError:
-                pass
-    return remove_package_ids

--- a/src/ctirs/api/v1/package_id/views.py
+++ b/src/ctirs/api/v1/package_id/views.py
@@ -19,8 +19,8 @@ def stix_files_package_id(request, package_id):
             return get_stix_file_package_id_document_info(request, package_id)
         elif request.method == 'DELETE':
             # STIX ファイル情報削除
-            remove_package_ids = delete_stix_file_package_id_document_info(package_id)
-            return api_root.get_delete_normal_status({"remove_package_ids": remove_package_ids})
+            delete_stix_file_package_id_document_info(package_id)
+            return api_root.get_delete_normal_status({'remove_package_id': package_id})
         else:
             return HttpResponseNotAllowed(['GET', 'DELETE'])
     except Exception as e:
@@ -41,8 +41,7 @@ def get_stix_file_package_id_document_info(request, package_id):
 # DELETE /api/v1/stix_files_package_id/<package_id>
 def delete_stix_file_package_id_document_info(package_id):
     try:
-        remove_package_ids = api_root.delete_stix_related_document(package_id=package_id)
-        return remove_package_ids
+        api_root.delete_stix_document(package_id=package_id)
     except Exception as e:
         return api_root.error(e)
 

--- a/src/ctirs/api/v1/stix_files_v2/views.py
+++ b/src/ctirs/api/v1/stix_files_v2/views.py
@@ -217,9 +217,9 @@ def _delete_object_main(request, object_id):
     if not doc:
         return error(Exception(object_id + ' does not exist.'))
     try:
-        remove_package_ids = delete_stix_file_package_id_document_info(doc.package_id)
+        delete_stix_file_package_id_document_info(doc.package_id)
         resp = get_normal_response_json()
-        resp['data'] = {"remove_package_ids": remove_package_ids}
+        resp['data'] = {'remove_package_id': doc.package_id}
         return JsonResponse(resp, status=200, safe=False)
     except Exception as e:
         import traceback


### PR DESCRIPTION
Issue about #115 .

When an user used the DELETE REST API, S-TIP set a delete flag not to return by TAXII 2.1 server.
I also modified a return value format from list to string (because it always delete only one STIX file, it does not need to return as a list).

