### PR TITLE
Fixed an issue about a STIX 2.1 content without an objects property.

### DIFF
--- a/src/ctirs/core/mongo/documents_stix.py
+++ b/src/ctirs/core/mongo/documents_stix.py
@@ -301,6 +301,10 @@ class StixFiles(Document):
         try:
             f = open(self.origin_path, 'r', encoding='utf-8')
             j = json.load(f)
+            if 'objects' not in j:
+                self.save()
+                f.close()
+                return
             objects = j['objects']
             self.taxii2_stix_objects = []
             for object_ in objects:
@@ -464,7 +468,7 @@ class StixFiles(Document):
         return d
 
     def get_rest_api_document_content(self):
-        return {'content': self.content.read()}
+        return {'content': self.content.read().decode('utf-8')}
 
     def get_webhook_document(self):
         return self.get_rest_api_document_info()

--- a/src/ctirs/models/sns/feeds/models.py
+++ b/src/ctirs/models/sns/feeds/models.py
@@ -442,7 +442,8 @@ class Feed(models.Model):
         stix_file_path = rs.get_stix_file_path(api_user, package_id)
         with open(stix_file_path, 'r', encoding='utf-8') as fp:
             bundle = json.load(fp)
-
+        if 'objects' not in bundle:
+            return None
         if not feed:
             feed = Feed()
         feed.stix_version = version
@@ -765,7 +766,8 @@ class Feed(models.Model):
         packages_from_rs = rs.query(api_user, query_string, size)
         for package_from_rs in packages_from_rs:
             feed = Feed.get_feeds_from_package_from_rs(api_user, package_from_rs)
-            feeds_.append(feed)
+            if feed:
+                feeds_.append(feed)
         return feeds_
 
     @staticmethod
@@ -808,7 +810,8 @@ class Feed(models.Model):
         feeds_ = []
         for package_from_rs in packages_from_rs:
             feed = Feed.get_feeds_from_package_from_rs(api_user, package_from_rs)
-            feeds_.append(feed)
+            if feed:
+                feeds_.append(feed)
         return Feed.get_filter_query_set(None, api_user, feeds_=feeds_)
 
     @staticmethod


### PR DESCRIPTION
Issue about #117 .

When S-TIP receives a new STIX 2.1 content, SNS attempt to create a Feed cache.
However if this STIX does not contain a objects property, SNS fails to create it.
S-TIP SNS should ignore these STIX contents.
