### PR TITLE
Authenticate on SNS API

### DIFF
--- a/src/ctirs/api/v1/decolators.py
+++ b/src/ctirs/api/v1/decolators.py
@@ -1,0 +1,13 @@
+import ctirs.api as api_root
+
+
+def api_key_auth(f):
+    def wrap(request, *args, **kwargs):
+        ctirs_auth_user = api_root.authentication(request)
+        if ctirs_auth_user is None:
+            return api_root.error(Exception('You have no permission for this operation.'))
+        return f(request, *args, **kwargs)
+
+    wrap.__doc__ = f.__doc__
+    wrap.__name__ = f.__name__
+    return wrap

--- a/src/ctirs/api/v1/gv/views.py
+++ b/src/ctirs/api/v1/gv/views.py
@@ -210,7 +210,7 @@ def _get_exact_matched_info(package_id):
     ret_observable_cashes = []
 
     cache_collections = [
-        ObservableCaches,  # STIX 1.x/2.x の Observables
+        ObservableCaches,
         ExploitTargetCaches,
     ]
 

--- a/src/ctirs/api/v1/gv/views.py
+++ b/src/ctirs/api/v1/gv/views.py
@@ -10,7 +10,7 @@ from mongoengine.queryset.visitor import Q
 from django.http import HttpResponseNotAllowed
 from django.http.response import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from ctirs.api import error, authentication, get_normal_response_json
+from ctirs.api import error, get_normal_response_json
 from ctirs.core.mongo.documents import Communities
 from ctirs.core.mongo.documents_stix import ObservableCaches, SimilarScoreCache, StixFiles, \
     StixCampaigns, StixIncidents, StixIndicators, StixObservables, StixThreatActors, \
@@ -20,8 +20,8 @@ from stip.common.tld import TLD
 from mongoengine import DoesNotExist
 from .stix2_indicator import _get_observed_data
 from ctirs.models.rs.models import System
+from ctirs.api.v1.decolators import api_key_auth
 
-# EDGE 文字列
 EXACT_EDGE_TYPE = 'Exact'
 SIMILARTY_1_EDGE_TYPE = 'Similarity: 1'
 SIMILARTY_2_EDGE_TYPE = 'Similarity: 2'
@@ -33,8 +33,6 @@ SIMILARTY_7_EDGE_TYPE = 'Similarity: 7'
 SIMILARTY_8_EDGE_TYPE = 'Similarity: 8'
 
 
-# 共通
-# REST API から boolean の値を取得する
 def get_boolean_value(d, key, default_value):
     if key not in d:
         return default_value
@@ -47,28 +45,17 @@ def get_boolean_value(d, key, default_value):
 
 
 # GET /api/v1/gv/l1_info_for_l1table
-# L1用 table 返却
+@api_key_auth
 def l1_info_for_l1table(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # ajax parameter取得
-        # 表示する長さ
+
         iDisplayLength = int(request.GET['iDisplayLength'])
-        # 表示開始位置インデックス
         iDisplayStart = int(request.GET['iDisplayStart'])
-        # 検索文字列
         sSearch = request.GET['sSearch']
-        # ソートする列
         sort_col = int(request.GET['iSortCol'])
-        # ソート順番 (desc指定で降順)
         sort_dir = request.GET['sSortDir']
-        # alias情報
-        # 存在しない場合は空としてあつかつ
         try:
             aliases_str = request.GET['aliases']
             alias_lists = json.loads(aliases_str)
@@ -84,65 +71,45 @@ def l1_info_for_l1table(request):
         SORT_INDEX_DESCRIPTION = 4
         SORT_INDEX_TIMESTAMP = 5
 
-        # type
         if sort_col == SORT_INDEX_TYPE:
             order_query = 'type'
-        # value
         elif sort_col == SORT_INDEX_VALUE:
             order_query = 'value'
-        # pacakge_name
         elif sort_col == SORT_INDEX_PACKAGE_NAME:
             order_query = 'package_name'
-        # title
         elif sort_col == SORT_INDEX_TILE:
             order_query = 'title'
-        # description
         elif sort_col == SORT_INDEX_DESCRIPTION:
             order_query = 'description'
-        # timestamp
         elif sort_col == SORT_INDEX_TIMESTAMP:
             order_query = 'produced'
 
-        # 昇順/降順
         if order_query is not None:
-            # descが降順
             if sort_dir == 'desc':
                 order_query = '-' + order_query
 
-        # query
-        # 検索ワードをリスト化
         tmp_sSearches = list(set(sSearch.split(' ')))
-        # 空要素は取り除く
         if '' in tmp_sSearches:
             tmp_sSearches.remove('')
 
-        # 検索リスト作成
         sSearches = []
         for item in tmp_sSearches:
-            # まず、元の単語は追加する
             sSearches.append(item)
-            # alias_lists 1つずつチェックする
             for alias_list in alias_lists:
-                # 検索ワードがalias_listにあれば、そのリストに含まれるすべての単語が検索対象
                 if item in alias_list:
                     sSearches.extend(alias_list)
 
-        # 重複を省く
         sSearches = list(set(sSearches))
 
-        # Filterを作成する
         filters = Q()
-        # alias含め、その文字列が含まれていたらヒットとする
         for sSearch in sSearches:
             filters = filters | Q(type__icontains=sSearch)
             filters = filters | Q(value__icontains=sSearch)
             filters = filters | Q(package_name__icontains=sSearch)
             filters = filters | Q(title__icontains=sSearch)
             filters = filters | Q(description__icontains=sSearch)
-        # 検索
         objects = ObservableCaches.objects.filter(filters).order_by(order_query)
 
-        # 検索結果から表示範囲のデータを抽出する
         data = []
         for d in objects[iDisplayStart:(iDisplayStart + iDisplayLength)]:
             r = {}
@@ -157,7 +124,6 @@ def l1_info_for_l1table(request):
             r['observable_id'] = d.observable_id
             data.append(r)
 
-        # response data 作成
         r_data = {}
         r_data['iTotalRecords'] = ObservableCaches.objects.count()
         r_data['iTotalDisplayRecords'] = objects.count()
@@ -171,6 +137,7 @@ def l1_info_for_l1table(request):
 
 
 # GET /api/v1/gv/package_list
+@api_key_auth
 def package_list(request):
     REQUIRED_COMMENT_KEY = 'required_comment'
     LIMIT_KEY = 'limit'
@@ -179,20 +146,13 @@ def package_list(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
 
         required_comment = False
         if (REQUIRED_COMMENT_KEY in request.GET):
             if request.GET[REQUIRED_COMMENT_KEY].lower() == 'true':
                 required_comment = True
 
-        # 全取得
         stix_files = StixFiles.objects.filter()
-        # order_by指定があればソートする
-        # それ以外に場合はpackage_nameを辞書順でソートする
         if (ORDER_BY_KEY in request.GET):
             try:
                 stix_files = stix_files.order_by(request.GET[ORDER_BY_KEY])
@@ -201,17 +161,14 @@ def package_list(request):
         else:
             stix_files = stix_files.order_by(DEFAULT_ORDER_BY)
 
-        # limit取得
         try:
             limit = int(request.GET[LIMIT_KEY])
         except BaseException:
             limit = None
-        # 指定があれば上位の指定数だけを返却する
         if limit is not None:
             stix_files = stix_files[:limit]
 
         rsp_stix_files = []
-        # 返却データ作成
         for stix_file in stix_files:
             rsp_stix_files.append(stix_file.get_rest_api_document_info(required_comment))
         resp = get_normal_response_json()
@@ -223,30 +180,22 @@ def package_list(request):
 
 
 # GET /api/v1/gv/package_name_list
+@api_key_auth
 def package_name_list(request):
     LIMIT_KEY = 'limit'
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
 
-        # 全取得
         stix_files = StixFiles.objects.filter(Q(is_post_sns__ne=False)).only('package_name', 'package_id').order_by('package_name')
-
-        # limit取得
         try:
             limit = int(request.GET[LIMIT_KEY])
         except BaseException:
             limit = None
-        # 指定があれば上位の指定数だけを返却する
         if limit is not None:
             stix_files = stix_files[:limit]
 
         rsp_stix_files = []
-        # 返却データ作成
         for stix_file in stix_files:
             rsp_stix_files.append(stix_file.get_rest_api_package_name_info())
         resp = get_normal_response_json()
@@ -257,11 +206,9 @@ def package_name_list(request):
         return error(e)
 
 
-# exact matchした情報を取得する
 def _get_exact_matched_info(package_id):
     ret_observable_cashes = []
 
-    # match 検索対象の cache list
     cache_collections = [
         ObservableCaches,  # STIX 1.x/2.x の Observables
         ExploitTargetCaches,
@@ -270,8 +217,6 @@ def _get_exact_matched_info(package_id):
     for cache_collection in cache_collections:
         caches = cache_collection.objects.filter(package_id=package_id)
         for cache in caches:
-            # type,valueが一緒で、検索 package_idと異なる Cache を検索 (observables 間検索)
-            # Obaservable の値がない場合はスキップする
             if cache.value is None:
                 continue
             exacts = cache_collection.objects.filter(
@@ -280,9 +225,7 @@ def _get_exact_matched_info(package_id):
                 & Q(package_id__ne=package_id))
             ret_observable_cashes.extend(exacts)
 
-            # ObservableCaches の検索の場合はさらに その Observable が STIX v2 の indicator pattern 文字列にヒットするか判定する
             if isinstance(cache, ObservableCaches):
-                # Observable と STIX 2.x の indicators 間
                 indicator_v2_cachses = IndicatorV2Caches.objects.filter(Q(package_id__ne=package_id))
                 for indicator_v2_cache in indicator_v2_cachses:
                     observed_data = _get_observed_data(cache)
@@ -290,36 +233,27 @@ def _get_exact_matched_info(package_id):
                     if len(matches) != 0:
                         indicator_v2_cache.type = cache.type
                         indicator_v2_cache.value = cache.value
-                        # start_node の検索先は ObservableCaches or ExploitTargetCaches
                         indicator_v2_cache.start_collection = cache_collection
-                        # 格納する end_info は (指定の package_id) の ObservableCache に該当する IndicatorV2Cache
                         ret_observable_cashes.append(indicator_v2_cache)
 
-    # STIX2 indicator cache の matching
     indicator_v2_caches = IndicatorV2Caches.objects.filter(package_id=package_id)
     for indicator_v2_cache in indicator_v2_caches:
-        # 対象の IndicatorV2Caches に Match する (Package_id は別の) ObservableCaches を検索する
         query_set = _get_observables_cashes_query(indicator_v2_cache.pattern, package_id)
         caches = ObservableCaches.objects.filter(query_set)
         for cache in caches:
             observed_data = _get_observed_data(cache)
             matches = matcher.match(indicator_v2_cache.pattern, [observed_data])
             if len(matches) != 0:
-                # start_info は IndicatorV2Caches から検索
                 cache.start_collection = IndicatorV2Caches
                 cache.pattern = indicator_v2_cache.pattern
-                # 格納する end_info は (指定の package_id) の Indicator v2 にマッチする ObservableCache
                 ret_observable_cashes.append(cache)
 
-        # 自分以外の PackageID で STIX2 indicator pattern を検索する
         exacts = IndicatorV2Caches.objects.filter(
             Q(pattern__exact=indicator_v2_cache.pattern)
             & Q(package_id__ne=package_id))
         for exact in exacts:
             exact.cache_list = IndicatorV2Caches
-            # start_node の検索先は ObservableCaches or ExploitTargetCaches
             exact.start_collection = IndicatorV2Caches
-            # 格納するのは (指定の package_id) の Indicator v2 にマッチする (指定の package_id 以外に)IndicatorV2Cache
             ret_observable_cashes.append(exact)
 
     label_caches = LabelCaches.objects.filter(package_id=package_id)
@@ -332,7 +266,6 @@ def _get_exact_matched_info(package_id):
     return ret_observable_cashes
 
 
-# pattern 文字列から ObservableCaches を絞り込む Query インスタンスを取得する
 url_pattern = re.compile(r'url:value\s*=\s*\'(\S+)\'')
 ipv4_pattern = re.compile(r'ipv4-addr:value\s*=\s*\'(\S+)\'')
 domain_name_pattern = re.compile(r'domain-name:value\s*=\s*\'(\S+)\'')
@@ -344,7 +277,6 @@ sha512_pattern = re.compile(r'file:hashes\.\'SHA-512\'\s*=\s*\'(\S+)\'')
 
 def _get_observables_cashes_query(pattern, package_id):
     q = Q()
-    # pattern 文字列から種別と値を正規表現で抽出し、 OR 検索で連結する
     for v in url_pattern.findall(pattern):
         q |= (Q(package_id__ne=package_id) & Q(type__exact='uri') & Q(value__exact=v))
     for v in ipv4_pattern.findall(pattern):
@@ -375,10 +307,8 @@ def _get_matches_observable_caches_vs_indicator_v2_cache(observable_caches, indi
     return ret_observable_cashes
 
 
-# IPv4 の類似結果情報を取得する
 def _get_similar_ipv4(package_id):
     CACHE_TYPE = 'ipv4'
-    # 指定の package_id で ipv4 のものを取得する
     cashes = ObservableCaches.objects.filter(
         package_id=package_id,
         type=CACHE_TYPE)
@@ -387,8 +317,6 @@ def _get_similar_ipv4(package_id):
         octets = cache.value.split('.')
         ipv4_1_3 = '.'.join(octets[0:3]) + '.'
         ipv4_4 = int(octets[3])
-        # ipv4 で 第3オクテットまで同一で,第4オクテットが異なり
-        # 検索 package_idと異なる Observable Cache を検索
         similar_ipv4_observable_caches = ObservableCaches.objects.filter(
             Q(type__exact=CACHE_TYPE)
             & Q(ipv4_1_3__exact=ipv4_1_3)
@@ -403,25 +331,19 @@ def _get_similar_ipv4(package_id):
     return r
 
 
-# domain の類似結果情報を取得する
 def _get_similar_domain(package_id):
     CACHE_TYPE = 'domain_name'
     rs_system = System.objects.get()
     tld = TLD(rs_system.public_suffix_list_file_path)
-    # 指定の package_id で domain_name のものを取得する
     cashes = ObservableCaches.objects.filter(
         package_id=package_id,
         type=CACHE_TYPE)
     r = []
     for start_cache in cashes:
         without_tld, domain_tld = tld.split_domain(start_cache.value)
-        # tld がない domain 名は similar 対象外
         if domain_tld is None:
             continue
         domain_last = without_tld.split('.')[-1]
-        # domain_name で TLD が同じで
-        # かつ、 TLD の直前のサーバー名(domain_last)が同じ
-        # 検索 package_idと異なる Observable Cache を検索
         similar_domain_observable_caches = ObservableCaches.objects.filter(
             Q(type__exact=CACHE_TYPE)
             & Q(domain_tld=domain_tld)
@@ -439,8 +361,6 @@ def _get_similar_domain(package_id):
     return r
 
 
-# domain の 類似度を判定する
-# すでにtypeがdomainであること、tldが一致していることが前提
 def _get_domain_similarity_type(start_cache, end_cache):
     try:
         score_cache = SimilarScoreCache.objects.get(
@@ -452,7 +372,6 @@ def _get_domain_similarity_type(start_cache, end_cache):
     except DoesNotExist:
         pass
 
-    # .区切りで抽出し、reverseする
     start_without_tld_list = list(reversed(start_cache.domain_without_tld.split('.')))
     end_without_tld_list = list(reversed(end_cache.domain_without_tld.split('.')))
     min_length = min(len(start_without_tld_list), len(end_without_tld_list))
@@ -487,12 +406,10 @@ def _get_domain_similarity_type(start_cache, end_cache):
     elif score == 1.0:
         edge_type = None
 
-    # cache 作成
     SimilarScoreCache.create(SimilarScoreCache.DOMAIN_SCORE_CACHE_TYPE, start_cache, end_cache, edge_type)
     return edge_type
 
 
-# IPv4 の 類似度を判定する
 def _get_ipv4_similarity_type(start_cache, end_cache):
     try:
         score_cache = SimilarScoreCache.objects.get(
@@ -503,7 +420,6 @@ def _get_ipv4_similarity_type(start_cache, end_cache):
         return score_cache.edge_type
     except DoesNotExist:
         pass
-    # 第4オクテットの差分の絶対値で判別
     delta = abs(start_cache.ipv4_4 - end_cache.ipv4_4)
     edge_type = ''
     if delta <= 2**1:
@@ -522,24 +438,20 @@ def _get_ipv4_similarity_type(start_cache, end_cache):
         edge_type = SIMILARTY_7_EDGE_TYPE
     else:
         edge_type = SIMILARTY_8_EDGE_TYPE
-    # cache 作成
     SimilarScoreCache.create(SimilarScoreCache.IPV4_SCORE_CACHE_TYPE, start_cache, end_cache, edge_type)
     return edge_type
 
 
-# 指定された IPv4 文字列の第4オクテットの数値を取得する
 def _get_ip_4th_value(ipv4):
     return int(ipv4.split('.')[3])
 
 
-# 関連 CTI 検索 (GV/API 経由共通)
 def get_matched_packages(package_id, exact=True, similar_ipv4=False, similar_domain=False):
     exact_dict = {}
     similar_ipv4_dict = {}
     similar_domain_dict = {}
     package_id_list = []
 
-    # exact match情報取得
     if exact:
         infos = _get_exact_matched_info(package_id)
         for info in infos:
@@ -550,7 +462,6 @@ def get_matched_packages(package_id, exact=True, similar_ipv4=False, similar_dom
             else:
                 exact_dict[key] += 1
 
-    # IPv4 類似度情報取得
     if similar_ipv4:
         infos = _get_similar_ipv4(package_id)
         for info in infos:
@@ -562,7 +473,6 @@ def get_matched_packages(package_id, exact=True, similar_ipv4=False, similar_dom
             else:
                 similar_ipv4_dict[key] += 1
 
-    # domain 類似度情報取得
     if similar_domain:
         infos = _get_similar_domain(package_id)
         for info in infos:
@@ -574,8 +484,6 @@ def get_matched_packages(package_id, exact=True, similar_ipv4=False, similar_dom
             else:
                 similar_domain_dict[key] += 1
 
-    # 返却データ作成
-    # package_id の set を作成(重複を省くため)
     package_id_set = list(set(package_id_list))
 
     ret = []
@@ -595,6 +503,7 @@ def get_matched_packages(package_id, exact=True, similar_ipv4=False, similar_dom
 
 
 # GET /api/v1/gv/matched_packages
+@api_key_auth
 def matched_packages(request):
     PACKAGE_ID_KEY = 'package_id'
     EXACT_KEY = 'exact'
@@ -603,10 +512,6 @@ def matched_packages(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
 
         package_id = request.GET[PACKAGE_ID_KEY]
         exact = get_boolean_value(request.GET, EXACT_KEY, True)
@@ -624,6 +529,7 @@ def matched_packages(request):
 
 # GET /api/v1/gv/contents_and_edges
 @csrf_exempt
+@api_key_auth
 def contents_and_edges(request):
     PACKAGE_ID_KEY = 'package_id'
     COMPARED_PACKAGE_IDS_KEY = 'compared_package_ids'
@@ -633,10 +539,6 @@ def contents_and_edges(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
 
         package_id = request.GET[PACKAGE_ID_KEY]
         compared_package_ids = request.GET.getlist(COMPARED_PACKAGE_IDS_KEY)
@@ -646,27 +548,19 @@ def contents_and_edges(request):
 
         edges = []
         if exact:
-            # exact match情報取得
-            # end_infos には compared_package_ids候補が格納される
             end_infos = _get_exact_matched_info(package_id)
             for end_info in end_infos:
-                # compared_package_ids に含まれていない package_id はskip
                 if end_info.package_id not in compared_package_ids:
                     continue
-                # 終点情報
                 end_node = {
                     'package_id': end_info.package_id,
                     'node_id': end_info.node_id
                 }
 
-                # 検索対象となるコレクションを取得
                 if hasattr(end_info, 'start_collection'):
-                    # start_collection 指定がある場合はそのコレクションから
                     collection = end_info.start_collection
                 else:
-                    # 指定がない場合は end_info と同じ
                     collection = type(end_info)
-                # コレクションから終点情報に合致する始点を検索
                 if collection == IndicatorV2Caches:
                     start_caches = collection.objects.filter(
                         package_id=package_id,
@@ -680,7 +574,6 @@ def contents_and_edges(request):
                         package_id=package_id,
                         type=end_info.type,
                         value=end_info.value)
-                # 開始位置情報と線情報を格納する
                 for start_cache in start_caches:
                     start_node = {
                         'package_id': package_id,
@@ -694,32 +587,25 @@ def contents_and_edges(request):
                     edges.append(edge)
 
         if similar_ipv4:
-            # similar ipv4情報取得
             end_infos = _get_similar_ipv4(package_id)
             for end_info in end_infos:
-                # compared_package_ids に含まれていない package_id はskip
                 end_cache = end_info['cache']
                 if end_cache.package_id not in compared_package_ids:
                     continue
-                # 終点情報
                 end_node = {
                     'package_id': end_cache.package_id,
                     'node_id': end_cache.node_id
                 }
-                # IPの値を取得
                 source_value = end_info['source_value']
-                # 終点情報に類似する始点を検索
                 start_caches = ObservableCaches.objects.filter(
                     package_id=package_id,
                     type=end_cache.type,
                     value=source_value)
                 for start_cache in start_caches:
-                    # 始点情報
                     start_node = {
                         'package_id': package_id,
                         'node_id': start_cache.node_id
                     }
-                    # IPv4 similarity計測
                     edge_type = _get_ipv4_similarity_type(start_cache, end_cache)
                     edge = {
                         'edge_type': edge_type,
@@ -729,21 +615,16 @@ def contents_and_edges(request):
                     edges.append(edge)
 
         if similar_domain:
-            # similar domain情報取得
             end_infos = _get_similar_domain(package_id)
             for end_info in end_infos:
-                # compared_package_ids に含まれていない package_id はskip
                 end_cache = end_info['cache']
                 if end_cache.package_id not in compared_package_ids:
                     continue
-                # 終点情報
                 end_node = {
                     'package_id': end_cache.package_id,
                     'node_id': end_cache.node_id
                 }
-                # IPの値を取得
                 source_value = end_info['source_value']
-                # 終点情報に類似する始点を検索
                 start_caches = ObservableCaches.objects.filter(
                     package_id=package_id,
                     type=end_cache.type,
@@ -752,12 +633,10 @@ def contents_and_edges(request):
                     edge_type = _get_domain_similarity_type(start_cache, end_cache)
                     if edge_type is None:
                         continue
-                    # 始点情報
                     start_node = {
                         'package_id': package_id,
                         'node_id': start_cache.node_id
                     }
-                    # domain domain計測
                     edge = {
                         'edge_type': edge_type,
                         'start_node': start_node,
@@ -765,15 +644,11 @@ def contents_and_edges(request):
                     }
                     edges.append(edge)
 
-        # contents作成
         contents = []
-        # pacakge_id指定分
         contents.append(_get_contents_item(package_id))
-        # compared_package_ids指定分
         for compared_package_id in compared_package_ids:
             contents.append(_get_contents_item(compared_package_id))
 
-        # 返却データ作成
         data = {}
         data['contents'] = contents
         data['edges'] = edges
@@ -787,50 +662,35 @@ def contents_and_edges(request):
 
 
 # GET /api/v1/gv/package_list_for_sharing_table
-# sharing table (package)返却
+@api_key_auth
 def package_list_for_sharing_table(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # ajax parameter取得
-        # 表示する長さ
+
         iDisplayLength = int(request.GET['iDisplayLength'])
-        # 表示開始位置インデックス
         iDisplayStart = int(request.GET['iDisplayStart'])
-        # 検索文字列
         sSearch = request.GET['sSearch']
-        # ソートする列
         sort_col = int(request.GET['iSortCol'])
-        # ソート順番 (desc指定で降順)
         sort_dir = request.GET['sSortDir']
 
         order_query = None
         SORT_INDEX_PACKAGE_NAME = 3
 
-        # pakcage_name
         if sort_col == SORT_INDEX_PACKAGE_NAME:
             order_query = 'package_name'
 
-        # 昇順/降順
         if order_query is not None:
-            # descが降順
             if sort_dir == 'desc':
                 order_query = '-' + order_query
 
-        # 検索対象のコミュニティリストを検索
         community_objects = Communities.objects.filter(name__icontains=sSearch)
-        # 検索
         objects = StixFiles.objects.filter(
             Q(package_name__icontains=sSearch)
             | Q(input_community__in=community_objects)) \
             .order_by(order_query)
         objects = objects.filter(Q(is_post_sns__ne=False))
 
-        # 検索結果から表示範囲のデータを抽出する
         data = []
         for d in objects[iDisplayStart:(iDisplayStart + iDisplayLength)]:
             r = {}
@@ -843,7 +703,6 @@ def package_list_for_sharing_table(request):
                 r['input_community'] = ''
             data.append(r)
 
-        # response data 作成
         r_data = {}
         r_data['iTotalRecords'] = StixFiles.objects.count()
         r_data['iTotalDisplayRecords'] = objects.count()
@@ -856,15 +715,13 @@ def package_list_for_sharing_table(request):
         return error(e)
 
 # /api/v1/stix_files
-# GET/POSTの受付
 @csrf_exempt
+@api_key_auth
 def stix_files_id(request, package_id):
     try:
         if request.method == 'GET':
-            # stix_file一覧取得
             return get_stix_files_id(request, package_id)
         elif request.method == 'DELETE':
-            # stix_file削除
             return delete_stix_files_id(request, package_id)
         else:
             return HttpResponseNotAllowed(['GET', 'DELETE'])
@@ -873,16 +730,9 @@ def stix_files_id(request, package_id):
 
 
 # GET /api/v1/gv/stix_file/<package_id>
-# stix_file 返却
 def get_stix_files_id(request, package_id):
     try:
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # 検索
         stix_file = StixFiles.objects.get(package_id=package_id)
-        # response data 作成
         resp = get_normal_response_json()
         resp['data'] = stix_file.to_dict()
         return JsonResponse(resp)
@@ -892,39 +742,26 @@ def get_stix_files_id(request, package_id):
 
 
 # DELETE /api/v1/gv/stix_file/<package_id>
-# stix_file 削除
 def delete_stix_files_id(request, package_id):
     try:
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # mongoから該当レコード削除
         origin_path = StixFiles.delete_by_package_id(package_id)
-        # ファイル削除
         if os.path.exists(origin_path):
             os.remove(origin_path)
-        # response data 作成
         return JsonResponse({}, status=204)
     except Exception as e:
         traceback.print_exc()
         return error(e)
 
 # PUT /api/v1/gv/stix_file/<package_id>/comment
-# stix コメント変更
 @csrf_exempt
+@api_key_auth
 def stix_file_comment(request, package_id):
     try:
         if request.method != 'PUT':
             return HttpResponseNotAllowed(['PUT'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
         if 'comment' not in request.GET:
             return error(Exception('No input comment.'))
         comment = request.GET['comment']
-        # 検索してコメント保存
         stix_file = StixFiles.objects.get(package_id=package_id)
         stix_file.comment = comment
         stix_file.save()
@@ -935,19 +772,13 @@ def stix_file_comment(request, package_id):
 
 
 # GET /api/v1/gv/stix_file/<package_id>/l1_info
-# L1情報取得
+@api_key_auth
 def stix_file_l1_info(request, package_id):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
 
-        # 該当するキャッシュを検索する
         caches = ObservableCaches.objects.filter(package_id=package_id)
-        # 返却データを作成する
         data = []
         for cache in caches:
             r = {
@@ -956,7 +787,6 @@ def stix_file_l1_info(request, package_id):
                 'observable_id': cache.observable_id,
             }
             data.append(r)
-        # response data 作成
         resp = get_normal_response_json()
         resp['data'] = data
         return JsonResponse(resp)
@@ -966,15 +796,11 @@ def stix_file_l1_info(request, package_id):
 
 
 # GET /api/v1/gv/stix_file/<package_id>/stix
-# STIX content 作成
+@api_key_auth
 def stix_file_stix(request, package_id):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
         resp = get_normal_response_json()
         stix_file = StixFiles.objects.get(package_id=package_id)
         resp['data'] = _get_stix_content_dict(stix_file)
@@ -985,15 +811,12 @@ def stix_file_stix(request, package_id):
 
 
 # GET /api/v1/gv/communities
-# STIX content 作成
+@api_key_auth
 def communities(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
+
         resp = get_normal_response_json()
         resp['data'] = []
         for community in Communities.objects.all():
@@ -1005,16 +828,12 @@ def communities(request):
 
 
 # GET /api/v1/gv/count_by_type
-# STIX content 作成
+@api_key_auth
 def count_by_type(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # 返却データ作成
+
         ret_types = [
             ('Packages', StixFiles.objects.count()),
             ('Campaigns', StixCampaigns.objects.count()),
@@ -1042,15 +861,13 @@ def count_by_type(request):
 
 
 # GET /api/v1/gv/latest_package_list
+@api_key_auth
 def latest_package_list(request):
     DEFAULT_LATEST_NUM = 10
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
+
         try:
             num = int(request.GET['num'])
         except BaseException:
@@ -1058,7 +875,6 @@ def latest_package_list(request):
 
         resp = get_normal_response_json()
         resp['data'] = []
-        # producedを降順でソート
         for stix_file in StixFiles.objects.order_by('-produced')[:num]:
             resp['data'] .append(stix_file.get_rest_api_document_info())
         return JsonResponse(resp)
@@ -1068,22 +884,17 @@ def latest_package_list(request):
 
 
 def count_by_community(community, latest_days):
-    # latest_days が -1 指定の場合(ALL 指定の場合)
     if latest_days == -1:
-        # 最古の produced を取得し、現在までの差分を計算し latest_days とする
         oldest_stix_file = StixFiles.objects.order_by('produced').limit(1)[0]
         delta = datetime.datetime.now() - oldest_stix_file.produced
-        # oldest_stix_fileが時間指定でカウントさせれるように時間差分追加
         latest_days = (delta.days) + 2
 
-    # 指定のcommunityのlatest_daysまでの全 document 取得
     today = datetime.datetime.now(pytz.utc)
     past_day = _get_past_day(today, latest_days - 1)
     objects = StixFiles.objects.filter(
         Q(input_community=community)
         & Q(produced__gte=past_day))
 
-    # 取得した document を日付ごとにカウント
     date_count = {}
     for item in objects:
         date_string = item.produced.strftime('%Y-%m-%d')
@@ -1092,12 +903,9 @@ def count_by_community(community, latest_days):
         else:
             date_count[date_string] = 1
 
-    # 返却データ作成
     ret = []
     for i in range(latest_days):
-        # 1日おきの日付文字列を作成する
         past_day = _get_past_day(today, i)
-        # 1日幅で指定のコミュニティの件数をカウントする
         date_string = past_day.strftime('%Y-%m-%d')
         if (date_string in date_count):
             num = date_count[date_string]
@@ -1111,7 +919,6 @@ def count_by_community(community, latest_days):
     return ret
 
 
-# 本日から指定の数日分のdatetime型(00:00:00固定)を返却
 def _get_past_day(today, delta_int):
     past_delta = datetime.timedelta(days=delta_int)
     past_day = today - past_delta
@@ -1120,26 +927,20 @@ def _get_past_day(today, delta_int):
 
 
 # GET /api/v1/gv/latest_stix_count_by_community
-# 1日ごとの各コミュニティーごとのファイル数を返却する
+@api_key_auth
 def latest_stix_count_by_community(request):
     LASTEST_DAYS_KEY = 'latest_days'
     DEFAULT_LATEST_DAYS = 7
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # 最新何日からカウントするか取得する
+
         try:
             latest_days = int(request.GET[LASTEST_DAYS_KEY])
         except BaseException:
             latest_days = DEFAULT_LATEST_DAYS
-        # 返却データ作成
         resp = get_normal_response_json()
         resp['data'] = []
-        # communityごとにカウントする
         for community in Communities.objects.all():
             count = count_by_community(community, latest_days)
             d = {
@@ -1154,15 +955,11 @@ def latest_stix_count_by_community(request):
 
 
 # GET /api/v1/gv/language_contents
+@api_key_auth
 def language_contents(request):
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 認証する
-        user = authentication(request)
-        if user is None:
-            return error(Exception('You have no permission for this operation.'))
-        # 表示する長さ
         object_ref = request.GET['object_ref']
         object_modified = request.GET['object_modified']
         objects = StixLanguageContents.objects.filter(
@@ -1179,18 +976,14 @@ def language_contents(request):
         return error(e)
 
 
-# package_id指定のstix辞書形式を返却
 def _get_stix_content_dict(stix_file):
     if stix_file.version.startswith('2.'):
-        # STIX 2.x
         return json.loads(stix_file.content.read())
     else:
-        # STIX 1.x
         stix_package = STIXPackage.from_xml(stix_file.origin_path)
         return stix_package.to_dict()
 
 
-# contents_and_edgesで返却するpackage_idごとの辞書を作成する
 def _get_contents_item(package_id):
     stix_file = StixFiles.objects.get(package_id=package_id)
     return {

--- a/src/ctirs/api/v1/package_id/views.py
+++ b/src/ctirs/api/v1/package_id/views.py
@@ -2,23 +2,18 @@ from django.http import HttpResponseNotAllowed
 from django.views.decorators.csrf import csrf_exempt
 from django.http.response import JsonResponse
 import ctirs.api as api_root
+from ctirs.api.v1.decolators import api_key_auth
 from ctirs.core.mongo.documents_stix import StixFiles
 from ctirs.api.v1.gv.views import get_matched_packages
 
-# STIXファイル情報取得/削除
 # /api/v1/stix_files_package_id/<package_id>
 @csrf_exempt
+@api_key_auth
 def stix_files_package_id(request, package_id):
-    # apikey認証
-    ctirs_auth_user = api_root.authentication(request)
-    if ctirs_auth_user is None:
-        return api_root.error(Exception('You have no permission for this operation.'))
     try:
         if request.method == 'GET':
-            # STIX ファイル情報取得
             return get_stix_file_package_id_document_info(request, package_id)
         elif request.method == 'DELETE':
-            # STIX ファイル情報削除
             delete_stix_file_package_id_document_info(package_id)
             return api_root.get_delete_normal_status({'remove_package_id': package_id})
         else:
@@ -27,7 +22,6 @@ def stix_files_package_id(request, package_id):
         return api_root.error(e)
 
 
-# STIX ファイル情報取得
 # GET /api/v1/stix_files_package_id/<package_id>
 def get_stix_file_package_id_document_info(request, package_id):
     try:
@@ -37,7 +31,6 @@ def get_stix_file_package_id_document_info(request, package_id):
         return api_root.error(Exception('The specified id not found.'))
 
 
-# STIX ファイル情報削除
 # DELETE /api/v1/stix_files_package_id/<package_id>
 def delete_stix_file_package_id_document_info(package_id):
     try:
@@ -46,13 +39,9 @@ def delete_stix_file_package_id_document_info(package_id):
         return api_root.error(e)
 
 
-# STIX ファイル取得
 # GET /api/v1/stix_files_package_id/<package_id>/stix
+@api_key_auth
 def stix_files_package_id_stix(request, package_id):
-    # apikey認証
-    ctirs_auth_user = api_root.authentication(request)
-    if ctirs_auth_user is None:
-        return api_root.error(Exception('You have no permission for this operation.'))
     try:
         doc = StixFiles.objects.get(package_id=package_id)
         return api_root.get_rest_api_document_content(doc)
@@ -60,13 +49,9 @@ def stix_files_package_id_stix(request, package_id):
         return api_root.error(e)
 
 
-# 関連 CTI 取得
 # GET /api/v1/stix_files_package_id/<package_id>/related_packages
+@api_key_auth
 def stix_files_package_id_related_packages(request, package_id):
-    # apikey認証
-    ctirs_auth_user = api_root.authentication(request)
-    if ctirs_auth_user is None:
-        return api_root.error(Exception('You have no permission for this operation.'))
     try:
         ret = get_matched_packages(package_id)
         return JsonResponse(ret, safe=False)

--- a/src/ctirs/api/v1/sns/views.py
+++ b/src/ctirs/api/v1/sns/views.py
@@ -8,6 +8,7 @@ from django.http import HttpResponseNotAllowed
 from django.views.decorators.csrf import csrf_exempt
 from django.http.response import JsonResponse, HttpResponseNotFound
 from ctirs.api import error
+from ctirs.api.v1.decolators import api_key_auth
 from ctirs.core.mongo.documents import Vias, MispAdapter
 from ctirs.core.mongo.documents_stix import StixFiles, ObservableCaches, Tags
 from ctirs.core.adapter.misp.upload.control import MispUploadAdapterControl
@@ -26,10 +27,7 @@ STIP_SNS_USER_NAME_PREFIX = 'User Name: '
 SUGGEST_LIMIT = 5
 SUGGEST_MIN_LENGTH = 2 
 
-# 共通
-#     : 指定文字列は str(datetime) / 2018-02-22 08:54:47.187184 形式で GMT のタイムゾーン時間帯で送る
-#     : +09:00 のようなtimezone付きは python 2.7 ではサポートしていないようなのでつけない
-# 文字列からdatetime型を返却する
+
 def get_datetime_from_str(s, default=None):
     try:
         return datetime.datetime.strptime(s, '%Y-%m-%d %H:%M:%S.%f').replace(tzinfo=pytz.utc)
@@ -37,81 +35,55 @@ def get_datetime_from_str(s, default=None):
         return default
 
 
-# GET /api/v1/sns/feeds
-# start_time の 引数を返却
 def get_feeds_start_time(request):
-    # 引数1: start_time : この時間を最新として古い順に検索する
-    #     : デフォルトは datetime.datetime.now()
-    #     : 指定文字列は str(datetime) / 2018-02-22 08:54:47.187184 形式で GMT のタイムゾーン時間帯で送る
-    #     : +09:00 のようなtimezone付きは python 2.7 ではサポートしていないようなのでつけない
     try:
         start_time_str = request.GET['start_time']
     except KeyError:
         start_time_str = None
-    # 文字列指定があれば
     if start_time_str is not None:
         start_time = get_datetime_from_str(start_time_str, default=datetime.datetime.now(pytz.utc))
     else:
-        # 指定なし現在時刻
         start_time = datetime.datetime.now(pytz.utc)
     return start_time
 
 
-# GET /api/v1/sns/feeds
-# last_feed の 引数を返却
 def get_feeds_last_feed(request):
-    # last_feed : この時間より新しいフィードを取得する
     try:
         last_feed_str = request.GET['last_feed']
     except KeyError:
         last_feed_str = None
-    # 文字列指定があれば
     if last_feed_str is not None:
         last_feed = get_datetime_from_str(last_feed_str, default=None)
     else:
-        # 指定なし
         last_feed = None
     return last_feed
 
 
-# GET /api/v1/sns/feeds
-# range_big_datetime の 引数を返却
 def get_feeds_range_big_datetime(request):
-    # range_big_datetime
     try:
         str_ = request.GET['range_big_datetime']
     except KeyError:
         str_ = None
-    # 文字列指定があれば
     if str_ is not None:
         dt = get_datetime_from_str(str_, default=None)
     else:
-        # 指定なし
         dt = None
     return dt
 
 
-# GET /api/v1/sns/feeds
-# range_small_datetime の 引数を返却
 def get_feeds_range_small_datetime(request):
-    # range_small_datetime
     try:
         str_ = request.GET['range_small_datetime']
     except KeyError:
         str_ = None
-    # 文字列指定があれば
     if str_ is not None:
         dt = get_datetime_from_str(str_, default=None)
     else:
-        # 指定なし
         dt = None
     return dt
 
 
-# GET /api/v1/sns/feeds
-# content の 引数を返却
 def get_feeds_content(request):
-    # 引数3: content : contentを返却するときはTrue(大文字小文字問わず)指定。デフォルトはFalse
     try:
         return request.GET['content'].lower() == 'true'
     except KeyError:
@@ -120,8 +92,6 @@ def get_feeds_content(request):
         return False
 
 
-# GET /api/v1/sns/feeds
-# user_id の 引数を返却 (longで)
 def get_feeds_user_id(request):
     try:
         return int(request.GET['user_id'])
@@ -131,8 +101,6 @@ def get_feeds_user_id(request):
         return None
 
 
-# GET /api/v1/sns/feeds
-# instance の 引数を返却 (longで)
 def get_feeds_instance(request):
     try:
         return request.GET['instance']
@@ -140,20 +108,14 @@ def get_feeds_instance(request):
         return None
 
 
-# GET /api/v1/sns/feeds
-# index の 引数を返却
 def get_feeds_index(request):
     return get_int_value(request, 'index')
 
 
-# GET /api/v1/sns/feeds
-# size の 引数を返却
 def get_feeds_size(request):
     return get_int_value(request, 'size')
 
 
-# 引数の文字列を int 変換して返却
-# key がない, 変換失敗時は default 返却
 def get_int_value(request, key, default=0):
     try:
         return int(request.GET[key])
@@ -163,25 +125,18 @@ def get_int_value(request, key, default=0):
         return default
 
 
-# GET /api/v1/sns/attaches
-# package_id の 引数を返却
 def get_attaches_package_id(request):
     return get_package_id_from_get_argument(request)
 
 
-# GET /api/v1/sns/comments
-# package_id の 引数を返却
 def get_comments_original_package_id(request):
     return get_package_id_from_get_argument(request)
 
 
-# GET /api/v1/sns/content
-# package_id の 引数を返却
 def get_content_original_package_id(request):
     return get_package_id_from_get_argument(request)
 
 
-# package_id の version を返却
 def get_content_version(request):
     try:
         return request.GET['version']
@@ -189,15 +144,11 @@ def get_content_version(request):
         return None
 
 
-# GET /api/v1/sns/check
-# last_time の 引数を返却
 def get_check_last_datetime(request):
-    # 引数1: last_datetime : この時間より新しい日時の個数を検索する
     try:
         last_time_str = request.GET['last_feed_time']
     except KeyError:
         last_time_str = None
-    # 文字列指定があれば
     if last_time_str is not None:
         last_time = get_datetime_from_str(last_time_str, default=None)
     else:
@@ -205,8 +156,6 @@ def get_check_last_datetime(request):
     return last_time
 
 
-# GET /api/v1/sns/check
-# usr_id の 引数を返却
 def get_check_user_id(request):
     try:
         return request.GET['user_id']
@@ -214,8 +163,6 @@ def get_check_user_id(request):
         return None
 
 
-# GET /api/v1/sns/query
-# query_string の 引数を返却
 def get_query_query_string(request):
     try:
         return request.GET['query_string']
@@ -223,7 +170,6 @@ def get_query_query_string(request):
         return None
 
 
-# GET パラメタから package_id を取得する
 def get_package_id_from_get_argument(request):
     try:
         return request.GET['package_id']
@@ -231,14 +177,12 @@ def get_package_id_from_get_argument(request):
         return None
 
 
-# StixFile ドキュメントから返却辞書を作成
 def get_return_dictionary_from_stix_file_document(stix_file, content=False):
     d = {}
     d['package_id'] = str(stix_file.package_id)
     d['package_name'] = stix_file.package_name
     d['created'] = str(stix_file.created)
     d['produced'] = str(stix_file.produced)
-    # uploader は STIPUser の ID
     d['uploader'] = str(stix_file.via.uploader)
     if content:
         d['content'] = stix_file.content.read().decode('utf-8')
@@ -248,55 +192,41 @@ def get_return_dictionary_from_stix_file_document(stix_file, content=False):
 
 # GET /api/v1/sns/feeds
 @csrf_exempt
+@api_key_auth
 def feeds(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
 
-        # 引数取得
         start_time = get_feeds_start_time(request)
         last_feed = get_feeds_last_feed(request)
-        range_big_datetime = get_feeds_range_big_datetime(request)  # 期間範囲指定の大きい方(新しい方)。この時間を含む
-        range_small_datetime = get_feeds_range_small_datetime(request)  # 期間範囲指定の小さい方(古い方)。この時間を含む
+        range_big_datetime = get_feeds_range_big_datetime(request)
+        range_small_datetime = get_feeds_range_small_datetime(request)
         user_id = get_feeds_user_id(request)
         instance = get_feeds_instance(request)
         content = get_feeds_content(request)
         query_string = request.GET.get(key='query_string', default=None)
-        # index は 0 開始
         index = get_feeds_index(request)
-        size = get_feeds_size(request)  # 指定なし時は size = -1
+        size = get_feeds_size(request)
 
-        # 返却条件は SNS に返却
         QQ = Q(is_post_sns__ne=False)
         if last_feed is not None:
-            # last_feed の指定があった場合 (last_feed より新しい投稿を返却)
             QQ &= Q(produced__gt=last_feed)
         else:
-            # last_feed の指定がない場合 (start_timeを最新として古い投稿を返却)
             QQ &= Q(produced__lte=start_time)
 
-        # range_big_datetime 指定あり
-        # 最大より古く(<=)
         if range_big_datetime is not None:
             QQ &= Q(produced__lte=range_big_datetime)
-        # range_small_datetime 指定あり
-        # 最小より新しい(>=)
         if range_small_datetime is not None:
             QQ &= Q(produced__gte=range_small_datetime)
 
         if query_string is not None:
-            # 空白スペース区切りで分割
             query_strings = re.split('[ 　]', query_string)
-            # 空白スペース区切りで検索文字列が指定されていない場合
-            # (検索対象: 投稿/タイトル/ユーザ名/スクリーン名/タグ)(タグ以外は大文字小文字区別せず)
             if len(query_strings) == 1:
                 if check_symbols(query_strings[0]) and tag.is_tag(query_strings[0]):
                     QQ &= Q(sns_lower_tags__in=[query_strings[0].lower()])
                 else:
                     QQ &= Q(package_name__icontains=query_strings[0]) | Q(post__icontains=query_strings[0]) | Q(sns_user_name__icontains=query_strings[0]) | Q(sns_screen_name__icontains=query_strings[0])
-            # 空白スペース区切りの場合
-            # (検索対象: 投稿/タイトル/ユーザ名/スクリーン名/タグ)(タグ以外は大文字小文字区別せず)
             else:
                 f_flag = True
                 for q in query_strings:
@@ -313,19 +243,15 @@ def feeds(request):
                             query &= Q(package_name__icontains=q) | Q(post__icontains=q) | Q(sns_user_name__icontains=q) | Q(sns_screen_name__icontains=q)
                 QQ &= query
 
-        # user_id が指定の場合はその user_id の投稿のみを抽出
         from ctirs.models.rs.models import STIPUser
         if user_id is not None:
             stip_user = STIPUser.objects.get(id=user_id)
             QQ &= (
-                # SNS 産 STIX なら instance 名とユーザ名が一致した
                 (Q(is_created_by_sns=True) & Q(sns_user_name=stip_user.username) & Q(sns_instance=instance))
-                # SNS 産以外の STIX なら ユーザ名が一致した
                 | (Q(is_created_by_sns__ne=True) & Q(sns_user_name=stip_user.username))
             )
 
         else:
-            # 未定の場合は存在している STIP_USER だけ有効
             stip_users = STIPUser.objects.only('id')
             stip_user_list = []
             for stip_user in stip_users:
@@ -333,14 +259,10 @@ def feeds(request):
             stip_users_vias = Vias.objects.filter(uploader__in=stip_user_list)
             QQ & Q(via__in=stip_users_vias)
 
-        # count = 0
         feeds_list = []
         stix_files = StixFiles.objects(QQ).order_by('-produced').skip(index).timeout(False)
-        # サイズ指定がある場合は limit 設定
         if size != -1:
             stix_files = stix_files.limit(size)
-        # 指定された数値分 StixFiles から取得する(produced順にソートする かつ is_post_sns が False以外 かつ version が 2.0 以外)
-        # for stix_file in StixFiles.objects(QQ).order_by('-produced').all().timeout(False):
         for stix_file in stix_files:
             feeds_list.append(get_return_dictionary_from_stix_file_document(stix_file, content=content))
         r = {}
@@ -354,24 +276,20 @@ def feeds(request):
 
 # GET /api/v1/sns/attaches
 @csrf_exempt
+@api_key_auth
 def attaches(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
 
-        # 引数取得
         package_id = get_attaches_package_id(request)
         if package_id is None:
-            print('/api/v1/sns/attaches package_id is None.')
             return HttpResponseNotFound()
         try:
             stix_file = StixFiles.objects.get(package_id=package_id)
             d = get_return_dictionary_from_stix_file_document(stix_file)
             return JsonResponse(d, safe=False)
         except DoesNotExist:
-            # 該当レコードがなかった
-            print('/api/v1/sns/attaches DoesNotExist (%s)' % (str(package_id)))
             return HttpResponseNotFound()
     except Exception as e:
         import traceback
@@ -381,18 +299,16 @@ def attaches(request):
 
 # GET /api/v1/sns/related_packages
 @csrf_exempt
+@api_key_auth
 def related_packages(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 引数取得
+
         original_package_id = get_comments_original_package_id(request)
         if original_package_id is None:
-            print('/api/v1/sns/related_packages package_id is None.')
             return HttpResponseNotFound()
         related_packages_list = []
-        # original_package_id を related_packages リスト要素に含む stix_fileを返却
         for stix_file in StixFiles.objects(related_packages=original_package_id):
             related_packages_list.append(get_return_dictionary_from_stix_file_document(stix_file))
         return JsonResponse(related_packages_list, safe=False)
@@ -404,17 +320,16 @@ def related_packages(request):
 
 # GET /api/v1/sns/content
 @csrf_exempt
+@api_key_auth
 def content(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 引数取得
+
         package_id = get_content_original_package_id(request)
         version = get_content_version(request)
 
         if package_id is None:
-            print('/api/v1/sns/content package_id is None.')
             return HttpResponseNotFound()
 
         stix_file = StixFiles.objects.get(package_id=package_id)
@@ -454,18 +369,16 @@ def _get_stix_file_document(stix_file):
 
 # GET /api/v1/sns/comments
 @csrf_exempt
+@api_key_auth
 def comments(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 引数取得
+
         original_package_id = get_comments_original_package_id(request)
         if original_package_id is None:
-            print('/api/v1/sns/comments package_id is None.')
             return HttpResponseNotFound()
         comments_list = []
-        # original_package_id を related_packages リスト要素に含み sns_type が comment の stix_fileを返却
         for stix_file in StixFiles.objects(Q(related_packages=original_package_id) & Q(sns_type=StixFiles.STIP_SNS_TYPE_COMMENT)):
             comments_list.append(get_return_dictionary_from_stix_file_document(stix_file))
         return JsonResponse(comments_list, safe=False)
@@ -477,18 +390,16 @@ def comments(request):
 
 # GET /api/v1/sns/likers
 @csrf_exempt
+@api_key_auth
 def likers(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 引数取得
+
         original_package_id = get_comments_original_package_id(request)
         if original_package_id is None:
-            print('/api/v1/sns/likers package_id is None.')
             return HttpResponseNotFound()
         liker_dict = {}
-        # original_package_id を related_packages リスト要素に含む stix_fileを返却
         for stix_file in StixFiles.objects(Q(related_packages=original_package_id) & Q(sns_type=StixFiles.STIP_SNS_TYPE_LIKE)):
             liker = stix_file.get_unique_name()
             if liker is not None:
@@ -497,7 +408,6 @@ def likers(request):
                 else:
                     liker_dict[liker] = 1
 
-        # original_package_id を related_packages リスト要素に含む stix_fileを返却
         for stix_file in StixFiles.objects(Q(related_packages=original_package_id) & Q(sns_type=StixFiles.STIP_SNS_TYPE_UNLIKE)):
             unliker = stix_file.get_unique_name()
             if unliker is not None:
@@ -518,12 +428,12 @@ def likers(request):
 
 # GET /api/v1/sns/share_misp
 @csrf_exempt
+@api_key_auth
 def share_misp(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 引数取得
+
         package_id = get_package_id_from_get_argument(request)
         mc = MispUploadAdapterControl()
         j = mc.upload_misp(package_id)
@@ -544,34 +454,27 @@ def share_misp(request):
 
 # GET /api/v1/sns/query
 @csrf_exempt
+@api_key_auth
 def query(request):
     try:
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
-        # 引数取得
-        size = get_feeds_size(request)  # 指定なし時は size = -1
+
+        size = get_feeds_size(request)
         query_string = get_query_query_string(request)
-        # query_string  未指定時は空リスト返却
         if query_string is None:
             r = {}
             r['feeds'] = []
             return JsonResponse(r, safe=False)
 
-        # 返却条件は SNS に返却　かつ　version 2.0 以外
         QQ = Q(is_post_sns__ne=False) & Q(version__ne='2.0')
 
-        # 空白スペース区切りで分割
         query_strings = re.split('[ 　]', query_string)
-        # 空白スペース区切りで検索文字列が指定されていない場合
-        # (検索対象: 投稿/タイトル/ユーザ名/スクリーン名/タグ)(タグ以外は大文字小文字区別せず)
         if len(query_strings) == 1:
             if check_symbols(query_strings[0]) and tag.is_tag(query_strings[0]):
                 QQ &= Q(sns_lower_tags__in=[query_strings[0].lower()])
             else:
                 QQ &= Q(package_name__icontains=query_strings[0]) | Q(post__icontains=query_strings[0]) | Q(sns_user_name__icontains=query_strings[0]) | Q(sns_screen_name__icontains=query_strings[0])
-        # 空白スペース区切りの場合
-        # (検索対象: 投稿/タイトル/ユーザ名/スクリーン名/タグ)(タグ以外は大文字小文字区別せず)
         else:
             f_flag = True
             for q in query_strings:
@@ -588,23 +491,18 @@ def query(request):
                         query &= Q(package_name__icontains=q) | Q(post__icontains=q) | Q(sns_user_name__icontains=q) | Q(sns_screen_name__icontains=q)
             QQ &= query
         stix_files = set([])
-        # Query
         for stix_file in StixFiles.objects(QQ).order_by('-produced').timeout(False):
             stix_files.add(stix_file)
 
-        # ObservableCache から query_string を含む StixFile の set を作成
         for observable_cache in ObservableCaches.objects.filter(Q(value__icontains=query_string)):
             stix_file = StixFiles.objects.get(package_id=observable_cache.package_id)
             stix_files.add(stix_file)
 
-        # 時間でソートする
         stix_files = sorted(list(stix_files), key=lambda s: s.produced, reverse=True)
 
-        # サイズ指定がある場合は上位から指定sizeを取得
         if size != -1:
             stix_files = stix_files[:size]
 
-        # 返却データ作成
         feeds_list = []
         for stix_file in stix_files:
             feeds_list.append(get_return_dictionary_from_stix_file_document(stix_file, content=content))
@@ -617,7 +515,6 @@ def query(request):
         return error(e)
 
 
-# S-TIP SNS の STIX から User Name を返却する
 def get_stip_sns_username(stix_package):
     try:
         for marking in stix_package.stix_header.handling:
@@ -631,19 +528,14 @@ def get_stip_sns_username(stix_package):
         return None
 
 
-# S-TIP SNS の Like STIX であれば Liker アカウントを返却
-# 未対象時は None 返却
 def get_liker(stix_package):
     if not is_stip_sns_stix(stix_package):
         return None
-    # Titile が Like to で始まっているもの
     if not stix_package.stix_header.title.startswith(STIP_SNS_LIKE_TITLE_PREFIX):
         return None
     return get_stip_sns_username(stix_package)
 
 
-# S-TIP SNS の Like STIX であれば Unliker アカウントを返却
-# 未対象時は None 返却
 def get_unliker(stix_package):
     if not is_stip_sns_stix(stix_package):
         return False
@@ -652,15 +544,12 @@ def get_unliker(stix_package):
     return get_stip_sns_username(stix_package)
 
 
-# S-TIP SNS の Comment STIX か
 def is_stip_sns_comment_stix(stix_package):
     if not is_stip_sns_stix(stix_package):
         return False
-    # Titile が Comment to で始まっているもの
     return stix_package.stix_header.title.startswith(STIP_SNS_COMMENT_TITLE_PREFIX)
 
 
-# S-TIP SNS の STIX か
 def is_stip_sns_stix(stix_package):
     try:
         for tool in stix_package.stix_header.information_source.tools:
@@ -682,10 +571,10 @@ def check_symbols(word):
 
 # GET /api/v1/sns/feeds/tags
 @csrf_exempt
+@api_key_auth
 def tags(request):
     try:
         suggest_list = []
-        # GET 以外はエラー
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])
         word = request.GET.get('word')
@@ -693,7 +582,6 @@ def tags(request):
             return JsonResponse(suggest_list, safe=False)
         if word[0] != '#':
             return JsonResponse(suggest_list, safe=False)
-        # Get the top 5(SUGGEST_LIMIT) results, Alphabet ascending order.
         tags = Tags.objects.filter(tag__istartswith=word).order_by('tag').limit(SUGGEST_LIMIT)
         for tag in tags:
             suggest_list.append(tag.tag)

--- a/src/ctirs/api/v1/stix_files/views.py
+++ b/src/ctirs/api/v1/stix_files/views.py
@@ -1,11 +1,12 @@
 import pytz
 import datetime
-from mongoengine.errors import DoesNotExist
+from mongoengine.errors import DoesNotExist, ValidationError
 from django.http import HttpResponseNotAllowed
 from django.views.decorators.csrf import csrf_exempt
 from django.http.response import JsonResponse
 from stip.common import get_text_field_value
 import ctirs.api as api_root
+from ctirs.api.v1.decolators import api_key_auth
 from ctirs.core.mongo.documents import Communities, Vias
 from ctirs.core.mongo.documents_stix import StixFiles
 from ctirs.upload.views import upload_common
@@ -23,15 +24,13 @@ def get_api_get_stix_files_end(request):
     return get_text_field_value(request, 'end', default_value=None)
 
 # /api/v1/stix_files
-# GET/POSTの受付
 @csrf_exempt
+@api_key_auth
 def stix_files(request):
     try:
         if request.method == 'GET':
-            # stix_file一覧取得
             return get_stix_files(request)
         elif request.method == 'POST':
-            # stix_file追加
             return upload_stix_file(request)
         else:
             return HttpResponseNotAllowed(['GET', 'POST'])
@@ -39,19 +38,12 @@ def stix_files(request):
         return api_root.error(e)
 
 
-# 引数の日時文字列からdatetimeオブジェクトを作成
 def get_datetime_from_argument(s):
     return datetime.datetime.strptime(s, '%Y%m%d%H%M%S').replace(tzinfo=pytz.utc)
 
 
-# stix_file一覧取得
 # GET /api/v1/stix_files
 def get_stix_files(request):
-    # apikey認証
-    ctirs_auth_user = api_root.authentication(request)
-    if ctirs_auth_user is None:
-        return api_root.error(Exception('You have no permission for this operation.'))
-
     l = []
     query = {}
     # community filter
@@ -63,26 +55,23 @@ def get_stix_files(request):
             return api_root.error(Exception('The specified community not found.'))
 
     # start filter
-    # YYYYMMDDHHMMSS形式
     start = get_api_get_stix_files_start(request)
     if start is not None:
         try:
             d = get_datetime_from_argument(start)
             query['created__gt'] = d
-        except Exception as _:
+        except Exception:
             return api_root.error(Exception('Time string format invalid.'))
 
     # end filter
-    # YYYYMMDDHHMMSS形式
     end = get_api_get_stix_files_end(request)
     if end is not None:
         try:
             d = get_datetime_from_argument(end)
             query['created__lt'] = d
-        except Exception as _:
+        except Exception:
             return api_root.error(Exception('Time string format invalid.'))
 
-    # 検索
     for stix_files in StixFiles.objects.filter(**query):
         try:
             l.append(stix_files.get_rest_api_document_info())
@@ -91,15 +80,12 @@ def get_stix_files(request):
     return JsonResponse(l, safe=False)
 
 
-# STIXファイル追加
 # POST /api/v1/stix_files
 def upload_stix_file(request):
-    # apikey認証
     ctirs_auth_user = api_root.authentication(request)
     if ctirs_auth_user is None:
         return api_root.error(Exception('You have no permission for this operation.'))
     try:
-        # viaを取得
         via = Vias.get_via_rest_api_upload(uploader=ctirs_auth_user.id)
         upload_common(request, via)
         return api_root.get_put_normal_status()
@@ -109,20 +95,14 @@ def upload_stix_file(request):
         return api_root.error(e)
 
 
-# STIXファイル情報取得/削除
 # /api/v1/stix_files/<id_>
 @csrf_exempt
+@api_key_auth
 def stix_files_id(request, id_):
-    # apikey認証
-    ctirs_auth_user = api_root.authentication(request)
-    if ctirs_auth_user is None:
-        return api_root.error(Exception('You have no permission for this operation.'))
     try:
         if request.method == 'GET':
-            # STIX ファイル情報取得
             return get_stix_file_document_info(request, id_)
         elif request.method == 'DELETE':
-            # STIX ファイル情報削除
             delete_stix_file_document_info(id_)
             return api_root.get_delete_normal_status()
         else:
@@ -131,17 +111,15 @@ def stix_files_id(request, id_):
         return api_root.error(e)
 
 
-# STIX ファイル情報取得
 # GET /api/v1/stix_files/<id_>
 def get_stix_file_document_info(request, id_):
     try:
         doc = StixFiles.objects.get(id=id_)
         return api_root.get_rest_api_document_info(doc)
-    except Exception as _:
+    except Exception:
         return api_root.error(Exception('The specified id not found.'))
 
 
-# STIX ファイル情報削除
 # DELETE /api/v1/stix_files/<id_>
 def delete_stix_file_document_info(id_):
     try:
@@ -150,15 +128,13 @@ def delete_stix_file_document_info(id_):
         return api_root.error(e)
 
 
-# STIX取得
 # GET /api/v1/stix_files/<id>/stix
+@api_key_auth
 def stix_files_id_stix(request, id_):
-    # apikey認証
-    ctirs_auth_user = api_root.authentication(request)
-    if ctirs_auth_user is None:
-        return api_root.error(Exception('You have no permission for this operation.'))
     try:
         doc = StixFiles.objects.get(id=id_)
         return api_root.get_rest_api_document_content(doc)
     except DoesNotExist:
         return api_root.error(Exception('The specified id not found.'))
+    except ValidationError:
+        return api_root.error(Exception('The specified id is invalid.'))

--- a/src/ctirs/api/v1/stix_files_v2/views.py
+++ b/src/ctirs/api/v1/stix_files_v2/views.py
@@ -9,6 +9,7 @@ from django.http.response import JsonResponse
 from stip.common import get_text_field_value
 from stip.common.stip_stix2 import _get_stip_identname
 from ctirs.api import error, get_normal_response_json, authentication
+from ctirs.api.v1.decolators import api_key_auth
 from mongoengine.queryset.visitor import Q
 from ctirs.core.mongo.documents_stix import StixAttackPatterns, StixCampaignsV2,\
     StixCoursesOfActionV2, StixIdentities, StixIndicatorsV2, \
@@ -34,6 +35,7 @@ def get_api_stix_files_v2_sighting_count(request):
 
 # /api/v1/stix_files_v2/<observed_data_id>/sighting
 @csrf_exempt
+@api_key_auth
 def sighting(request, observed_data_id):
     ctirs_auth_user = authentication(request)
     if not ctirs_auth_user:
@@ -64,6 +66,7 @@ def sighting(request, observed_data_id):
 
 # /api/v1/stix_files_v2/<object_ref>/language_contents
 @csrf_exempt
+@api_key_auth
 def language_contents(request, object_ref):
     ctirs_auth_user = authentication(request)
     if not ctirs_auth_user:
@@ -184,10 +187,8 @@ def get_language_contents(request, object_ref):
 
 # /api/v1/stix_files_v2/object/<object_id>
 @csrf_exempt
+@api_key_auth
 def object_main(request, object_id):
-    ctirs_auth_user = authentication(request)
-    if not ctirs_auth_user:
-        return error(Exception('You have no permission for this operation.'))
     try:
         if request.method == 'GET':
             return _get_object_main(request, object_id)
@@ -251,11 +252,9 @@ def _get_document(object_id):
 
 
 # /api/v1/stix_files_v2/search_bundle
+@api_key_auth
 def search_bundle(request):
     SEARCH_KEY_OBJECT_ID = 'match[object_id]'
-    ctirs_auth_user = authentication(request)
-    if ctirs_auth_user is None:
-        return error(Exception('You have no permission for this operation.'))
     try:
         if request.method != 'GET':
             return HttpResponseNotAllowed(['GET'])


### PR DESCRIPTION
Issue about #120 .

I created a new authenticate decorator to use a REST APIKey and apply to all REST API.
I removed unnecessary Japanese comment lines.

---

#120 の issue の対応。
SNS 用の REST API に API Key 認証をしていませんでした。
今回、新しく REST APIKey を使って認証するデコレーター (`@api_key_auth) を新規作成してすべての REST API に適用しました。
また、これを機に日本語コメントも削除しました。
