### PR TITLE
Fixed to clear STIX v2 indicator caches

### DIFF
--- a/src/ctirs/core/mongo/documents_stix.py
+++ b/src/ctirs/core/mongo/documents_stix.py
@@ -140,6 +140,7 @@ class StixFiles(Document):
         LabelCaches.drop_collection()
         Tags.drop_collection()
         ExploitTargetCaches.drop_collection()
+        IndicatorV2Caches.drop_collection()
         SimilarScoreCache.drop_collection()
 
         StixAttackPatterns.drop_collection()


### PR DESCRIPTION
Issue about #123 .

Fixed to clear the STIX V2 indicator caches when an admin user rebuilds caches on the system configuration page.