### PR TITLE
Fixed an issue about  STIX 1.x parse error

### DIFF
--- a/src/ctirs/models/sns/feeds/models.py
+++ b/src/ctirs/models/sns/feeds/models.py
@@ -597,7 +597,8 @@ class Feed(models.Model):
     @staticmethod
     def create_feeds_record_v1(api_user, package_id, uploader_id, produced_str, version):
         stix_file_path = rs.get_stix_file_path(api_user, package_id)
-        stix_package = STIXPackage.from_xml(stix_file_path, encoding='utf-8')
+        #stix_package = STIXPackage.from_xml(stix_file_path, encoding='utf-8')
+        stix_package = STIXPackage.from_xml(stix_file_path)
 
         feed = Feed()
         feed.stix_version = version

--- a/src/ctirs/models/sns/feeds/models.py
+++ b/src/ctirs/models/sns/feeds/models.py
@@ -597,7 +597,6 @@ class Feed(models.Model):
     @staticmethod
     def create_feeds_record_v1(api_user, package_id, uploader_id, produced_str, version):
         stix_file_path = rs.get_stix_file_path(api_user, package_id)
-        #stix_package = STIXPackage.from_xml(stix_file_path, encoding='utf-8')
         stix_package = STIXPackage.from_xml(stix_file_path)
 
         feed = Feed()


### PR DESCRIPTION
Issue about #140 .

---

STIX 1.x のファイルをパースする (`STIXPackage.from_xml()`) 際に `encoding` を指定することができます。
通常なら指定しないのですが、指定する箇所が一か所あったために、
他の parse でエラーにならないところがエラーになってしまい処理が先に進めることができないことが
#140 のエラーの原因でした。

そのため、すべて、`encoding` 指定なしに統一します。
